### PR TITLE
Add DistroKid listen link for wormhusk single

### DIFF
--- a/src/components/hero/hero.astro
+++ b/src/components/hero/hero.astro
@@ -33,7 +33,9 @@ import { Image } from 'astro:assets'
 			<p class='text-2xl md:text-3xl font-bold text-white'>wormhusk</p>
 			<p class='text-ew-cream mt-2 mb-4'>Out now • 29.5.2026</p>
 			<a
-				href='#'
+				href='https://distrokid.com/hyperfollow/inthorns/wormhusk'
+				target='_blank'
+				rel='noopener noreferrer'
 				class='inline-block bg-ew-green hover:bg-ew-green-light text-white px-6 py-2 transition-colors text-sm uppercase tracking-wider'
 			>
 				Listen Now!

--- a/src/components/music/music.astro
+++ b/src/components/music/music.astro
@@ -27,7 +27,9 @@ import { Image } from 'astro:assets'
 				<p class='text-ew-cream/70 mb-6'>"what's left when the husk falls quiet."</p>
 				<div class='space-y-3'>
 					<a
-						href='#'
+						href='https://distrokid.com/hyperfollow/inthorns/wormhusk'
+						target='_blank'
+						rel='noopener noreferrer'
 						class='inline-block bg-ew-green hover:bg-ew-green-light text-white px-6 py-3 transition-colors'
 					>
 						Listen


### PR DESCRIPTION
Replace placeholder href='#' on all wormhusk Listen buttons with the
live DistroKid hyperfollow URL, matching the exit wounds pattern.

https://claude.ai/code/session_01Mid6iyTCywv185Yt2Zcmxe