### PR TITLE
Add wormhusk DistroKid link and Finnish EPK page

### DIFF
--- a/src/pages/epk-fi.astro
+++ b/src/pages/epk-fi.astro
@@ -1,0 +1,225 @@
+---
+import Layout from '@/layouts/Layout.astro'
+import { Image } from 'astro:assets'
+---
+
+<Layout title='In Thorns – Elektroninen lehdistöpaketti'>
+	<header>
+		<nav class='fixed top-0 left-0 right-0 z-50 bg-black/90 backdrop-blur-sm border-b border-ew-orange/30'>
+			<div class='container mx-auto px-4'>
+				<div class='flex items-center justify-between h-16'>
+					<a href='/' aria-label='Etusivulle' class='transition-transform hover:scale-105'>
+						<Image src='/it-logo-white.png' alt='In Thorns' width={192} height={48} class='h-12' loading='eager' />
+					</a>
+					<a href='/epk' class='text-ew-cream/70 hover:text-ew-orange transition-colors text-sm'>
+						In English →
+					</a>
+				</div>
+			</div>
+		</nav>
+	</header>
+
+	<main class='bg-black min-h-screen pt-16'>
+
+		<!-- Hero -->
+		<section class='py-20 px-4 border-b border-ew-orange/20'>
+			<div class='container mx-auto max-w-4xl text-center'>
+				<p class='text-ew-orange text-sm uppercase tracking-widest mb-4'>Elektroninen lehdistöpaketti</p>
+				<Image src='/it-logo-white.png' alt='In Thorns' width={600} height={150} class='mx-auto mb-8 max-w-xs md:max-w-md' loading='eager' />
+				<p class='text-ew-cream/70 text-lg'>Jyväskylä, Suomi • Metal</p>
+				<p class='text-ew-cream/50 text-sm mt-2'>inthornsband@gmail.com</p>
+			</div>
+		</section>
+
+		<!-- Bio -->
+		<section class='py-20 px-4 bg-gradient-to-b from-black via-ew-red-dark/20 to-black'>
+			<div class='container mx-auto max-w-4xl'>
+				<h2 class='text-4xl font-bold text-ew-red-light mb-12 text-center'>
+					<span class='inline-block' style='text-shadow: 0 0 20px rgba(255, 82, 82, 0.5);'>Bio</span>
+				</h2>
+				<div class='bg-black/50 border-2 border-ew-red/30 p-6 md:p-10 backdrop-blur-sm'>
+					<div class='prose prose-invert max-w-none'>
+						<p class='text-ew-cream/90 leading-relaxed mb-6'>
+							Jyväskyläläinen metalliyhtye In Thorns julkaisi uuden singlen "wormhusk" toukokuussa 2026. Yhtyeen arvostettua debyyttialbumia "the last bead on a cord of songs" (2024) seurasi Vuoden tulokas 2024 -tunnustus Kaaoszinen lukijaäänestyksessä. Livenä bändi tarjoaa tiukan, energisen esityksen, jossa visuaalisesti vangitseva show imaisee katsojan mukaansa synkkään ja surrealistiseen maailmaansa.
+						</p>
+						<p class='text-ew-cream/90 leading-relaxed mb-8'>
+							Yhtye rakentaa metalliaan murskaavien äänimaisemien, nihilistisen ja synkän runollisen sanoituksen sekä kohoavien melodioiden varaan. Surrealistisesta taiteesta ja kauhugenrestä inspiraationsa ammentava In Thorns tarjoaa mukaansatempaavan äänielämyksen, joka tasapainottaa tuhoavan raskauden ja aavemaisen kauneuden.
+						</p>
+
+						<h3 class='text-2xl text-ew-orange mt-8 mb-4'>Kokoonpano</h3>
+						<ul class='text-ew-cream/80 space-y-2 list-none pl-0'>
+							<li class='border-l-2 border-ew-orange/50 pl-4'>Kristian Ruutala (harsh vocals)</li>
+							<li class='border-l-2 border-ew-orange/50 pl-4'>Aleksi Statsevich (harsh vocals)</li>
+							<li class='border-l-2 border-ew-orange/50 pl-4'>Aavee Tikkanen (laulu/kitara)</li>
+							<li class='border-l-2 border-ew-orange/50 pl-4'>Aleksi Ruotsalainen (kitara)</li>
+							<li class='border-l-2 border-ew-orange/50 pl-4'>Jimi Kinnunen (rummut)</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- Discography -->
+		<section class='py-20 px-4 bg-black'>
+			<div class='container mx-auto max-w-4xl'>
+				<h2 class='text-4xl font-bold text-ew-orange mb-12 text-center'>
+					<span class='inline-block' style='text-shadow: 0 0 20px rgba(255, 107, 53, 0.5);'>Diskografia</span>
+				</h2>
+				<div class='grid md:grid-cols-3 gap-6'>
+					<!-- wormhusk -->
+					<div class='bg-gradient-to-br from-wh-purple-dark/10 to-wh-purple/10 border-2 border-wh-purple/30 p-6'>
+						<Image src='/music/WH%20SINGLE%20ART.png' alt='wormhusk' width={400} height={400} class='w-full aspect-square object-cover mb-4' />
+						<h3 class='text-white font-bold mb-1'>wormhusk</h3>
+						<p class='text-wh-purple-light text-sm mb-4'>Single • 29.5.2026</p>
+						<a
+							href='https://distrokid.com/hyperfollow/inthorns/wormhusk'
+							target='_blank'
+							rel='noopener noreferrer'
+							class='inline-block bg-ew-green hover:bg-ew-green-light text-white px-4 py-2 text-sm transition-colors'
+						>
+							Kuuntele
+						</a>
+					</div>
+					<!-- exit wounds -->
+					<div class='bg-gradient-to-br from-ew-orange/10 to-ew-green/10 border-2 border-ew-orange/30 p-6'>
+						<Image src='/music/exit-wounds-cover.webp' alt='exit wounds' width={400} height={400} class='w-full aspect-square object-cover mb-4' />
+						<h3 class='text-white font-bold mb-1'>exit wounds</h3>
+						<p class='text-ew-orange text-sm mb-4'>Single • 23.1.2026</p>
+						<a
+							href='https://distrokid.com/hyperfollow/inthorns/exit-wounds'
+							target='_blank'
+							rel='noopener noreferrer'
+							class='inline-block bg-ew-green hover:bg-ew-green-light text-white px-4 py-2 text-sm transition-colors'
+						>
+							Kuuntele
+						</a>
+					</div>
+					<!-- album -->
+					<div class='bg-gradient-to-br from-ew-red/10 to-ew-orange/10 border-2 border-ew-red/30 p-6'>
+						<Image src='/music/tlboacos-album.webp' alt='the last bead on a cord of songs' width={400} height={400} class='w-full aspect-square object-cover mb-4' />
+						<h3 class='text-white font-bold mb-1'>the last bead on a cord of songs</h3>
+						<p class='text-ew-red text-sm mb-4'>Albumi • 12.1.2024</p>
+						<a
+							href='https://open.spotify.com/album/4wUaeA2NL4yZq0OOzw8xUy'
+							target='_blank'
+							rel='noopener noreferrer'
+							class='inline-block bg-ew-red hover:bg-ew-red-light text-white px-4 py-2 text-sm transition-colors'
+						>
+							Kuuntele Spotifyssa
+						</a>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- Media / Press photos -->
+		<section class='py-20 px-4 bg-gradient-to-b from-black via-ew-green/5 to-black'>
+			<div class='container mx-auto max-w-4xl'>
+				<h2 class='text-4xl font-bold text-ew-orange mb-4 text-center'>
+					<span class='inline-block' style='text-shadow: 0 0 20px rgba(255, 107, 53, 0.5);'>Media</span>
+				</h2>
+				<p class='text-ew-cream/70 text-center mb-12'>Promokuvat, livekuvat ja musiikkivideot</p>
+				<div class='grid md:grid-cols-3 gap-6 mb-8'>
+					<a href='/gallery/exit-wounds' class='group border-2 border-ew-orange/30 hover:border-ew-orange transition-all overflow-hidden'>
+						<div class='aspect-square overflow-hidden'>
+							<Image src='/photos/exit_wounds/1.webp' alt='exit wounds promokuvat' width={400} height={400} class='w-full h-full object-cover group-hover:scale-110 transition-transform duration-500' />
+						</div>
+						<div class='p-4'>
+							<p class='text-white font-bold mb-1'>exit wounds</p>
+							<p class='text-ew-orange text-sm uppercase tracking-wider'>Promokuvat →</p>
+						</div>
+					</a>
+					<a href='/gallery/tlboacos' class='group border-2 border-ew-red/30 hover:border-ew-red transition-all overflow-hidden'>
+						<div class='aspect-square overflow-hidden'>
+							<Image src='/photos/tlbocos/2A2FE513-7654-45A3-9120-25FAD6AFF06C.webp' alt='the last bead on a cord of songs promokuvat' width={400} height={400} class='w-full h-full object-cover group-hover:scale-110 transition-transform duration-500' />
+						</div>
+						<div class='p-4'>
+							<p class='text-white font-bold mb-1'>the last bead on a cord of songs</p>
+							<p class='text-ew-red text-sm uppercase tracking-wider'>Promokuvat →</p>
+						</div>
+					</a>
+					<a href='/gallery/live' class='group border-2 border-ew-green/30 hover:border-ew-green transition-all overflow-hidden'>
+						<div class='aspect-square overflow-hidden'>
+							<Image src='/photos/live/poppari_2025/_X2A5650.webp' alt='livekuvat' width={400} height={400} class='w-full h-full object-cover group-hover:scale-110 transition-transform duration-500' />
+						</div>
+						<div class='p-4'>
+							<p class='text-white font-bold mb-1'>live</p>
+							<p class='text-ew-green text-sm uppercase tracking-wider'>Livekuvat →</p>
+						</div>
+					</a>
+				</div>
+				<!-- Videos -->
+				<div class='grid md:grid-cols-2 gap-6 md:max-w-[66.666%]'>
+					<a href='https://www.youtube.com/watch?v=N1hDSYaVzFU' target='_blank' rel='noopener noreferrer' class='group border-2 border-ew-orange/30 hover:border-ew-orange transition-all overflow-hidden'>
+						<div class='aspect-square overflow-hidden relative'>
+							<img src='https://img.youtube.com/vi/N1hDSYaVzFU/maxresdefault.jpg' alt='exit wounds musiikkivideo' class='w-full h-full object-cover group-hover:scale-110 transition-transform duration-500' />
+							<div class='absolute inset-0 flex items-center justify-center'>
+								<div class='w-14 h-14 rounded-full bg-ew-orange/80 group-hover:bg-ew-orange transition-all flex items-center justify-center'>
+									<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white' class='w-7 h-7 ml-1'><path d='M8 5v14l11-7z'/></svg>
+								</div>
+							</div>
+						</div>
+						<div class='p-4'>
+							<p class='text-white font-bold mb-1'>exit wounds</p>
+							<p class='text-ew-orange text-sm uppercase tracking-wider'>Musiikkivideo →</p>
+						</div>
+					</a>
+					<a href='https://www.youtube.com/watch?v=rjff_WUvBhk' target='_blank' rel='noopener noreferrer' class='group border-2 border-ew-red/30 hover:border-ew-red transition-all overflow-hidden'>
+						<div class='aspect-square overflow-hidden relative'>
+							<img src='https://img.youtube.com/vi/rjff_WUvBhk/maxresdefault.jpg' alt='xii musiikkivideo' class='w-full h-full object-cover group-hover:scale-110 transition-transform duration-500' />
+							<div class='absolute inset-0 flex items-center justify-center'>
+								<div class='w-14 h-14 rounded-full bg-ew-red/80 group-hover:bg-ew-red transition-all flex items-center justify-center'>
+									<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white' class='w-7 h-7 ml-1'><path d='M8 5v14l11-7z'/></svg>
+								</div>
+							</div>
+						</div>
+						<div class='p-4'>
+							<p class='text-white font-bold mb-1'>xii</p>
+							<p class='text-ew-red text-sm uppercase tracking-wider'>Musiikkivideo →</p>
+						</div>
+					</a>
+				</div>
+			</div>
+		</section>
+
+		<!-- Contact -->
+		<footer class='bg-black border-t-2 border-ew-orange/30 py-12 px-4'>
+			<div class='container mx-auto max-w-4xl'>
+				<div class='grid md:grid-cols-3 gap-8 mb-8'>
+					<div class='flex items-center justify-center md:justify-start'>
+						<Image src='/it-logo-white.png' alt='In Thorns' width={192} height={48} class='h-12' />
+					</div>
+					<div class='text-center'>
+						<h3 class='text-ew-orange text-lg mb-4'>Seuraa</h3>
+						<div class='flex gap-4 justify-center'>
+							<a href='https://www.instagram.com/inxthorns/' target='_blank' rel='noopener noreferrer' aria-label='Instagram' class='hover:opacity-70 transition-opacity'>
+								<Image src='/ig.png' alt='Instagram' width={32} height={32} class='w-8 h-8' />
+							</a>
+							<a href='https://open.spotify.com/artist/4b0Yziy8xm1VtefVI9ri2d?si=W41OIFdzQ5io5Lr0VZanwQ' target='_blank' rel='noopener noreferrer' aria-label='Spotify' class='hover:opacity-70 transition-opacity'>
+								<Image src='/spotify.png' alt='Spotify' width={32} height={32} class='w-8 h-8' />
+							</a>
+							<a href='https://www.youtube.com/@inthornsband' target='_blank' rel='noopener noreferrer' aria-label='YouTube' class='hover:opacity-70 transition-opacity'>
+								<Image src='/yt.png' alt='YouTube' width={32} height={32} class='w-8 h-8' />
+							</a>
+							<a href='https://www.facebook.com/inthorns' target='_blank' rel='noopener noreferrer' aria-label='Facebook' class='hover:opacity-70 transition-opacity'>
+								<Image src='/fb.png' alt='Facebook' width={32} height={32} class='w-8 h-8' />
+							</a>
+						</div>
+					</div>
+					<div class='text-center md:text-right'>
+						<h3 class='text-ew-orange text-lg mb-4'>Yhteydenotot ja bookkaukset</h3>
+						<p class='text-ew-cream'>
+							<a href='mailto:inthornsband@gmail.com' class='hover:text-ew-orange transition-colors'>
+								inthornsband@gmail.com
+							</a>
+						</p>
+					</div>
+				</div>
+				<div class='border-t border-ew-orange/20 pt-8 text-center text-ew-cream/50 text-sm'>
+					<p>&copy; 2025 In Thorns. Kaikki oikeudet pidätetään.</p>
+				</div>
+			</div>
+		</footer>
+
+	</main>
+</Layout>


### PR DESCRIPTION
## Summary

- Replace placeholder `href='#'` on wormhusk Listen buttons (hero + music section) with the live DistroKid link `https://distrokid.com/hyperfollow/inthorns/wormhusk`, matching the exit wounds pattern
- Add new Finnish EPK page at `/epk-fi` with translated bio, members, discography, media/gallery links, and contact section

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mid6iyTCywv185Yt2Zcmxe)_